### PR TITLE
feat: add tab completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 node_modules
+dist
 .env
 
 .vscode
 .DS_Store
 
 reports/*
+.yarn/releases/yarn-1.22.19.cjs
+.yarnrc

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,34 @@
 import { program } from './command';
 import './programs';
+import omelette, { TreeValue } from 'omelette';
+
+
+let cmdTree: TreeValue = {};
+const cmdHelper = program.createHelp();
+const cmds = cmdHelper.visibleCommands(program);
+
+cmds.forEach( cmd => {
+  const subTree = cmd.commands.map( subCmd => subCmd.name())
+  cmdTree[cmd.name()] = subTree;
+})
+
+// what the alias for the app should be, note: should match whatever alias you set up in your .<term>rc file
+const aliasName = 'lidocli';
+const ommy = omelette(aliasName).tree(cmdTree);
+ommy.init();
+
+// only use if you want it to try to setup the completions automatically
+if (~process.argv.indexOf('--setup')) {
+  try {
+    // Pick shell init file automatically
+    ommy.setupShellInitFile();
+  
+    // Or use a manually defined init file
+    // omyy.setupShellInitFile('~/.my_bash_profile')
+  
+  } catch (err) {
+    console.log("error setting up omelette");
+  }
+}
 
 program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "license": "MIT",
   "scripts": {
+    "build": "tsc",
     "testnet": "./testnet.sh",
     "lint": "eslint **/*.ts",
     "format": "eslint **/*.ts --fix",
@@ -10,6 +11,7 @@
     "@swc/core": "^1.3.35",
     "@types/node": "^18.13.0",
     "@types/node-fetch": "2",
+    "@types/omelette": "^0.4.2",
     "@types/prompts": "^2.4.3",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
@@ -26,6 +28,7 @@
     "ethers": "^6.2.2",
     "husky": "^8.0.3",
     "node-fetch": "2",
+    "omelette": "^0.4.17",
     "prompts": "^2.4.2"
   },
   "husky": {

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,39 @@ Step 2. Fill in the `.env` using `sample.env` as a template
 cp sample.env .env
 ```
 
+Step 3. (Optional) If you want tab-completion, do the following:
+
+* Set up an alias in your `.<term>rc` file (note this makes the alias global), eg:
+```bash
+# in bash
+alias lidocli="./testnet.sh $@"
+
+# in zsh (couldn't get alias method to work)
+lidocli() { /.testnet.sh $@ }
+```
+
+* Reload your shell, set up the completion (attempts to do it automatically, otherwise you might need to try to do it manually)
+```bash
+lidocli --setup
+```
+If you'd rather do it manually, [check the omelette instructions](https://github.com/f/omelette#manual-installation).
+
+* Reload your shell, eg:
+```shell
+# bash 
+source ~/.bashrc
+# and/or (depending)
+source ~/.bash_profile.rc
+
+# plain zsh
+source ~/.zshrc
+
+# omz on MacOS
+omz reload
+```
+
 ## Run
 
-Run `./testnet.sh` to see the list of available commands
+Run `./testnet.sh` to see the list of available commands.
+
+If using the tab completion, try `lidocli<tab><tab>` to see a list of parent level commands, and `lidocli <cmd><tabtab>` to see children (1 level deep only currently.)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "dist",
     "lib": ["DOM", "ES2021"],
     "target": "ES2020",
     "types": ["node"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,6 +223,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.13.0.tgz#0400d1e6ce87e9d3032c19eb6c58205b0d3f7850"
   integrity sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==
 
+"@types/omelette@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@types/omelette/-/omelette-0.4.2.tgz#fefaae32c8df08f44d0b9493ea3acf86143e4dcf"
+  integrity sha512-buPQ+d47ECrBzx3rmU3pFm6XTAlBy0AHNWVJXx3l8VAx+ejmvsgcAX2/a3kz6bxMoRSoF0As3Z/hprjw3ZOV6w==
+
 "@types/prompts@^2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.4.3.tgz#999efa34a32e4b42315e9cd78e916ec74285f4c9"
@@ -943,6 +948,11 @@ node-fetch@2:
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
   dependencies:
     whatwg-url "^5.0.0"
+
+omelette@^0.4.17:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/omelette/-/omelette-0.4.17.tgz#24f3ed85cfdd11d8365f16368c7169f8dc422d73"
+  integrity sha512-UlU69G6Bhu0XFjw3tjFZ0qyiMUjAOR+rdzblA1nLQ8xiqFtxOVlkhM39BlgTpLFx9fxkm6rnxNNRsS5GxE/yww==
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
- add basic tab completion via [omelette](https://github.com/f/omelette) (bash/zsh/fish)
- touch up readme

known issues:
- You'll get an error in zsh if due to the function not being relevant/working in any other directory except the project one.

![image](https://user-images.githubusercontent.com/27592/229372267-5d1f19ad-d827-4acd-a83c-e8c7a1bb373c.png)

This took way longer to get working than I'd like to admit. Could not figure out why normal alias wouldn't work in zsh until I randomly searched for an issue in omelette repo.