### PR TITLE
feat: add aggregate view for detailed exit requests

### DIFF
--- a/programs/exit-bus-oracle.ts
+++ b/programs/exit-bus-oracle.ts
@@ -56,8 +56,8 @@ oracle
     Object.entries(groupedRequests).forEach(([moduleId, requests]) => {
       const formattedRequests = formatExitRequestsDetailed(requests);
 
-      
       console.log('module', moduleId);
+
       if (agg) {
         const aggregatedRequestsByOperator = groupRequestsByOperator(formattedRequests);
         console.table(aggregatedRequestsByOperator);


### PR DESCRIPTION
- adds an option to `exit-bus-oracle exit-requests-detailed`, `-a` or `--agg`, to show retrieved requests in aggregated way (per operator)

![image](https://user-images.githubusercontent.com/27592/230316042-e3385062-57ac-4b4e-8abc-f4cfb749e07d.png)
