### PR TITLE
Added a check to skip validator status checking on BN

### DIFF
--- a/programs/exit-bus/exit-requests.ts
+++ b/programs/exit-bus/exit-requests.ts
@@ -79,6 +79,11 @@ export const fetchLastExitRequestsDetailed = async (forBlocks = 7200) => {
   // fetch exit requests from events on EL
   const requests = await fetchLastExitRequests(forBlocks, Number(blockNumber));
 
+  // skip validator status check if there are no exit requests
+  if (requests.length === 0) {
+    return [];
+  }
+
   // fetch validator from CL
   const validators = await fetchAllValidators(Number(slot));
   const validatorsMap = getValidatorsMap(validators);


### PR DESCRIPTION
Added a check to skip validator status checking when there are no exit requests to map them to. It saves quite some time and resources checking the BN, and running this command (8 mins on Holesky currently).