### PR TITLE
add missing name to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "lido-cli",
   "license": "MIT",
   "scripts": {
     "testnet": "./testnet.sh",


### PR DESCRIPTION
Without it we cannot build this package using `mkYarnPackage` in Nix.