### PR TITLE
Fix: Update PowerShell Module to Support `tsx`

### DIFF
--- a/lido-cli.psm1
+++ b/lido-cli.psm1
@@ -5,7 +5,7 @@ function Invoke-LidoCli {
     )
     
     # Construct the command with all passed arguments
-    $cmd = "yarn --silent ts-node ./index $($Arguments -join ' ')"
+    $cmd = "yarn --silent tsx ./index $($Arguments -join ' ')"
     
     # Execute in the same directory as the module
     Push-Location $PSScriptRoot


### PR DESCRIPTION
### 🛠️ Fix: Update PowerShell Module to Support `tsx`

This PR resolves an issue where the PowerShell module command `Invoke-LidoCli` was broken due to a change in the Lido CLI's execution method. The CLI recently transitioned from using `ts-node` to `tsx`, which caused compatibility problems with the existing PowerShell integration.

#### 🔧 Changes Made
- Replaced `ts-node` with `tsx` in the `Invoke-LidoCli` command to align with the updated Lido CLI execution method.

#### ✅ Outcome
- Restores functionality of the `Invoke-LidoCli` command in the PowerShell module.