### PR TITLE
feat: cmv2 target validators limit commands

### DIFF
--- a/programs/cmv2.ts
+++ b/programs/cmv2.ts
@@ -362,6 +362,25 @@ const printOperatorGroup = (group: FormattedOperatorGroup) => {
 
 const getCallOverrides = (blockTag?: number) => (blockTag == null ? {} : { blockTag });
 
+const printTargetLimitEffect = async (operatorId: string, targetLimit: bigint) => {
+  const summary = (await cmv2ModuleContract.getNodeOperatorSummary(operatorId)).toObject() as {
+    targetLimitMode: bigint;
+    targetValidatorsCount: bigint;
+    totalExitedValidators: bigint;
+    totalDepositedValidators: bigint;
+  };
+  const activeKeys = summary.totalDepositedValidators - summary.totalExitedValidators;
+  const excess = activeKeys > targetLimit ? activeKeys - targetLimit : 0n;
+
+  logger.log('Current target limit mode', summary.targetLimitMode, 'limit', summary.targetValidatorsCount);
+  logger.log(
+    'Active keys',
+    activeKeys,
+    `(deposited ${summary.totalDepositedValidators} - exited ${summary.totalExitedValidators})`,
+  );
+  logger.log('Keys above the new limit', excess > 0n ? chalk.yellow(excess.toString()) : excess.toString());
+};
+
 const listExistingOperatorIds = async (blockTag?: number): Promise<bigint[]> => {
   const overrides = getCallOverrides(blockTag);
   const total = await cmv2ModuleContract.getNodeOperatorsCount(overrides);
@@ -1323,6 +1342,29 @@ cmv2
     const { operatorId } = options;
 
     await contractCallTxWithConfirm(cmv2ModuleContract, 'confirmNodeOperatorManagerAddressChange', [operatorId]);
+  });
+
+cmv2
+  .command('set-target-limit')
+  .description('sets target validators limit (signer must hold STAKING_ROUTER_ROLE on the module)')
+  .requiredOption('-o, --operator-id <number>', 'node operator id')
+  .requiredOption('-l, --limit <number>', 'target limit')
+  .option('-h, --hard-limit', 'hard limit, forces exits of the keys above the limit', false)
+  .action(async (options) => {
+    const { operatorId, limit, hardLimit } = options;
+
+    await printTargetLimitEffect(operatorId, parseUInt(limit));
+    await authorizedCall(cmv2ModuleContract, 'updateTargetValidatorsLimits', [operatorId, hardLimit ? 2 : 1, limit]);
+  });
+
+cmv2
+  .command('unset-target-limit')
+  .description('unsets target validators limit')
+  .requiredOption('-o, --operator-id <number>', 'node operator id')
+  .action(async (options) => {
+    const { operatorId } = options;
+
+    await authorizedCall(cmv2ModuleContract, 'updateTargetValidatorsLimits', [operatorId, 0, 0]);
   });
 
 cmv2


### PR DESCRIPTION
## Problem

`nor set-target-limit` has no CMv2 counterpart. Setting a target limit on a CMv2 operator — the usual way to make VEBO request exits on a testnet — means encoding `updateTargetValidatorsLimits` by hand.

`sr set-validators-limit` is not an alternative for most signers: it goes through the StakingRouter, which checks `STAKING_MODULE_MANAGE_ROLE`.

## Changes

Add `cmv2 set-target-limit` and `cmv2 unset-target-limit`, mirroring the NOR commands:

```
./run.sh cmv2 set-target-limit -o 56 -l 15 -h
./run.sh cmv2 unset-target-limit -o 56
```

Same flags and the same mode mapping as `nor set-target-limit` (`-h` -> mode 2, otherwise mode 1, unset -> mode 0). The signer needs `STAKING_ROUTER_ROLE` on the CMv2 module, which is what gates `updateTargetValidatorsLimits` there.

Two intentional differences from the NOR version:

- `-o` and `-l` are `requiredOption`, so a missing flag fails with a clear message instead of encoding `undefined` and erroring inside ethers
- before sending, the command prints what the limit will do:

```
Current target limit mode 0 limit 0
Active keys 16 (deposited 16 - exited 0)
Keys above the new limit 1
```

The last line is the number of keys VEBO requests for exit with a hard limit. It exists because the active key count is easy to confuse with other per-operator numbers, and a limit set too low requests far more exits than intended.

The method is passed by name rather than by full signature, unlike the NOR command, because `updateTargetValidatorsLimits` is not overloaded on the CMv2 module — NOR still carries the legacy `(uint256, bool, uint256)` variant, which is why the explicit signature is needed there.

## Testing

Not yet exercised on-chain: our EOA does not hold `STAKING_ROUTER_ROLE` on the CMv2 module on Hoodi, and the role request is still pending. The read part (`getNodeOperatorSummary`, active keys, keys above the limit) is verified against Hoodi, and the encoded call matches the transactions used previously to set a CMv2 target limit on Hoodi.

`yarn lint` and `yarn check-types` report only failures that already exist on `develop` (8 lint errors, 2 type errors in `programs/omnibus-scripts/devnet-cmv2-start.ts`), none in the touched file.
